### PR TITLE
Fix Typo in "Signed Transaction" Message

### DIFF
--- a/quick-starts/react-solana-quick-start/src/components/signTransaction.tsx
+++ b/quick-starts/react-solana-quick-start/src/components/signTransaction.tsx
@@ -46,7 +46,7 @@ export function SignTransaction() {
           {isPending ? 'Signing...' : 'Sign'}
         </button>
       </form>
-      {signedTransaction && <div>Signed Trasaction: {signedTransaction}</div>}
+      {signedTransaction && <div>Signed Transaction: {signedTransaction}</div>}
       {error && (
         <div>Error: {error.message}</div>
       )}


### PR DESCRIPTION

Description:  
This pull request corrects a typo in the `signTransaction.tsx` component. The word `Trasaсtion` was changed to the correct spelling `Transaction` in the message displayed after a transaction is signed. No other logic or functionality was modified.
